### PR TITLE
Parameter of the randStr function in upper case

### DIFF
--- a/src/CommonUtil.php
+++ b/src/CommonUtil.php
@@ -32,7 +32,7 @@ class CommonUtil
      */
     public static function randStr($len = 6, $format = 'ALL')
     {
-        switch ($format) {
+        switch (strtoupper($format)) {
             case 'ALL':
                 $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-@#~';
                 break;


### PR DESCRIPTION
In this way, it facilitates and avoids errors in typing any lower-case text